### PR TITLE
make dependencies required rather than emit runtime errors.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         "hydra-core",
         "torch",
         "pytorch_lightning",
+        "pytorch-crf",
     ],
     test_requires=[
         "pytest",


### PR DESCRIPTION
Closes #1 